### PR TITLE
Usuário edita seu perfil público na plataforma

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,5 @@
+class ProfilesController < ApplicationController
+  def show
+    @profile = Profile.find(params[:id])
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,7 @@
 class ProfilesController < ApplicationController
-  before_action :authenticate_user!, only: %i[show]
+  before_action :authenticate_user!, only: %i[show edit update]
   before_action :fetch_profile_by_id, only: %i[show edit update]
+  before_action :redirect_unauthorized_user, only: %i[edit update]
 
   def show; end
 
@@ -18,5 +19,9 @@ class ProfilesController < ApplicationController
 
   def fetch_profile_by_id
     @profile = Profile.find(params[:id])
+  end
+
+  def redirect_unauthorized_user
+    redirect_to root_path, alert: t('alerts.unauthorized') unless current_user.profile == @profile
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,22 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!, only: %i[show]
+  before_action :fetch_profile_by_id, only: %i[show edit update]
 
-  def show
+  def show; end
+
+  def edit; end
+
+  def update
+    redirect_to @profile, notice: t('.success') if @profile.update(profile_params)
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:full_name, :bio, :country, :birth_date)
+  end
+
+  def fetch_profile_by_id
     @profile = Profile.find(params[:id])
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,6 @@
 class ProfilesController < ApplicationController
+  before_action :authenticate_user!, only: %i[show]
+
   def show
     @profile = Profile.find(params[:id])
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,9 @@
 class Profile < ApplicationRecord
   belongs_to :user
+
+  delegate :username, to: :user
+
+  def calculate_age
+    ((Time.zone.now - birth_date.to_time) / 1.year.seconds).floor
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,7 +3,9 @@ class Profile < ApplicationRecord
 
   delegate :username, to: :user
 
-  def calculate_age
+  def age
+    return nil if birth_date.blank?
+
     ((Time.zone.now - birth_date.to_time) / 1.year.seconds).floor
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one :profile, dependent: :destroy
+  after_create :create_profile!
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :username, presence: true, uniqueness: true
 
   has_one :profile, dependent: :destroy
   after_create :create_profile!

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,23 @@
+<%= form_with model: @profile do |f|%>
+    <div class="form-text-div">
+        <%= f.label :full_name %>
+        <%= f.text_field :full_name %>
+    </div>
+
+    <div class="form-text-area-div">
+        <%= f.label :bio %>
+        <%= f.text_area :bio %>
+    </div>
+
+    <div class="form-text-div">
+        <%= f.label :country %>
+        <%= f.text_field :country %>
+    </div>
+
+    <div class="form-date-div">
+        <%= f.label :birth_date %>
+        <%= f.date_field :birth_date %>
+    </div>
+
+    <%= f.submit t('buttons.save_changes') %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,7 @@
 <div id="profile-info">
     <p><%= @profile.username %></p>
-    <p><%= @profile.full_name %></p>
-    <p><%= @profile.bio %></p>
-    <p><%= @profile.country %></p>
-    <p><%= "#{@profile.calculate_age} anos"%></p>
+    <p><%= @profile.full_name if @profile.full_name.present? %></p>
+    <p><%= @profile.bio if @profile.bio.present?%></p>
+    <p><%= @profile.country if @profile.country.present? %></p>
+    <p><%= t('profiles.views.show.age', age: @profile.calculate_age) if @profile.birth_date.present? %></p>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,7 @@
+<div id="profile-info">
+    <p><%= @profile.username %></p>
+    <p><%= @profile.full_name %></p>
+    <p><%= @profile.bio %></p>
+    <p><%= @profile.country %></p>
+    <p><%= "#{@profile.calculate_age} anos"%></p>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,6 @@
+<div id="profile-navigation-bar">
+    <p><%= link_to t('profiles.views.show.edit_profile_link'), edit_profile_path(@profile) %></p>
+</div>
 <div id="profile-info">
     <p><%= @profile.username %></p>
     <p><%= @profile.full_name if @profile.full_name.present? %></p>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,10 +1,10 @@
 <div id="profile-navigation-bar">
-    <p><%= link_to t('profiles.views.show.edit_profile_link'), edit_profile_path(@profile) %></p>
+    <p><%= link_to t('profiles.views.show.edit_profile_link'), edit_profile_path(@profile) if @profile.user == current_user %></p>
 </div>
 <div id="profile-info">
     <p><%= @profile.username %></p>
     <p><%= @profile.full_name if @profile.full_name.present? %></p>
     <p><%= @profile.bio if @profile.bio.present?%></p>
     <p><%= @profile.country if @profile.country.present? %></p>
-    <p><%= t('profiles.views.show.age', age: @profile.calculate_age) if @profile.birth_date.present? %></p>
+    <p><%= t('profiles.views.show.age', age: @profile.age) if @profile.birth_date.present? %></p>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,8 @@
 <nav>
     <div id="page-title">
-        <h1>GamingSocialNetwork</h1>
+        <%= link_to root_path do%>
+            <h1>GamingSocialNetwork</h1>
+        <% end %>
     </div>
     <div id="user-nav">
         <% if user_signed_in? %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,7 +4,7 @@
     </div>
     <div id="user-nav">
         <% if user_signed_in? %>
-                <p><%= current_user.email %></p>
+                <p><%= link_to current_user.username, profile_path(current_user.profile) %></p>
                 <p><%= button_to I18n.t('devise.shared.links.sign_out'), destroy_user_session_path, method: :delete %></p>
         <% else %>
             <p><%= link_to I18n.t('devise.shared.links.sign_up'), new_user_registration_path %></p>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :username %><br />
+    <%= f.email_field :username, autocomplete: "username" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :username %><br />
-    <%= f.email_field :username, autocomplete: "username" %>
+    <%= f.text_field :username %>
   </div>
 
   <div class="field">

--- a/config/locales/alerts.pt-BR.yml
+++ b/config/locales/alerts.pt-BR.yml
@@ -1,0 +1,3 @@
+pt-BR:
+  alerts:
+    unauthorized: "Você não possui autorização para essa ação"

--- a/config/locales/buttons.pt-BR.yml
+++ b/config/locales/buttons.pt-BR.yml
@@ -1,3 +1,4 @@
 pt-BR:
   buttons:
-    create_user: Cadastrar
+    create_user: "Cadastrar"
+    save_changes: "Salvar"

--- a/config/locales/models/profiles.pt-BR.yml
+++ b/config/locales/models/profiles.pt-BR.yml
@@ -1,0 +1,16 @@
+pt-BR:
+  activerecord:
+    models:
+      profile:
+        one: "Perfil"
+        other: "Perfis"
+    attributes:
+      profile:
+        bio: "E-mail"
+        birth_date: "Confirme sua senha"
+        country: "Senha"
+        full_name: "Nome completo"
+  profiles:
+    views:
+      show:
+        age: "%{age} anos"

--- a/config/locales/models/profiles.pt-BR.yml
+++ b/config/locales/models/profiles.pt-BR.yml
@@ -6,11 +6,14 @@ pt-BR:
         other: "Perfis"
     attributes:
       profile:
-        bio: "E-mail"
-        birth_date: "Confirme sua senha"
-        country: "Senha"
+        bio: "Bio"
+        birth_date: "Data de nascimento"
+        country: "País"
         full_name: "Nome completo"
   profiles:
+    update:
+      success: "Seu perfil foi alterado com sucesso"
     views:
       show:
         age: "%{age} anos"
+        edit_profile_link: "Editar perfil"

--- a/config/locales/models/users.pt-BR.yml
+++ b/config/locales/models/users.pt-BR.yml
@@ -1,5 +1,15 @@
 pt-BR:
   activerecord:
+    models:
+      user:
+        one: "Usuário"
+        other: "Usuários"
+    attributes:
+      user:
+        username: "Nome de usuário"
+        email: "E-mail"
+        password: "Senha"
+        password_confirmation: "Confirme sua senha"
     errors:
       models:
         user:
@@ -11,3 +21,5 @@ pt-BR:
                 blank: "não pode ficar em branco"
               password_confirmation:
                 confirmation: "não é igual a senha"
+              username:
+                blank: "não pode ficar em branco"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "home#index"
-  resources :profiles, only: %i[show]
+  resources :profiles, only: %i[show edit update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "home#index"
+  resources :profiles, only: %i[show]
 end

--- a/db/migrate/20240318220824_create_profiles.rb
+++ b/db/migrate/20240318220824_create_profiles.rb
@@ -1,0 +1,13 @@
+class CreateProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :birth_date
+      t.string :full_name
+      t.text :bio
+      t.string :country
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240318223900_add_username_to_user.rb
+++ b/db/migrate/20240318223900_add_username_to_user.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :username, :string, null: false
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_172445) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_18_220824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "birth_date"
+    t.string "full_name"
+    t.text "bio"
+    t.string "country"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +37,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_172445) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_220824) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_18_223900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,8 +33,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_220824) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "profiles", "users"

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Profile, type: :model do
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,4 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Profile, type: :model do
+  context '#calculate_age' do
+    it 'calculates the correct age' do
+      profile = Profile.new(birth_date: 47.years.ago)
+
+      expect(profile.calculate_age).to eq(47)
+    end
+  end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,11 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Profile, type: :model do
-  context '#calculate_age' do
+  context '#age' do
     it 'calculates the correct age' do
       profile = Profile.new(birth_date: 47.years.ago)
 
-      expect(profile.calculate_age).to eq(47)
+      expect(profile.age).to eq 47
+    end
+
+    it 'returns nil if birth_date is blank' do
+      profile = Profile.new
+
+      expect(profile.age).to be_nil
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it 'creates a related profile instance after creation' do
+    user = User.create!(email: 'peyton@manning.com', password: 'broncocolts18')
+
+    expect(Profile.count).to eq 1
+    expect(user.profile).to be_a(Profile)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it 'creates a related profile instance after creation' do
-    user = User.create!(email: 'peyton@manning.com', password: 'broncocolts18')
+    user = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
 
     expect(Profile.count).to eq 1
     expect(user.profile).to be_a(Profile)

--- a/spec/requests/profiles/user_updates_profile_spec.rb
+++ b/spec/requests/profiles/user_updates_profile_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'PATCH profiles/:id/', type: :request do
+  context 'with authorization' do
+    it 'successfully from the profile page, changing all of the information at once' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      profile_params = { profile:
+        { full_name: 'Peyton Manning',
+          bio: 'Former NFL quarterback, 5x NFL MVP',
+          country: 'USA',
+          birth_date: 47.years.ago.strftime('%Y-%m-%d') } }
+
+      login_as peyton
+      patch profile_path(peyton.profile.id), params: profile_params
+      peyton.profile.reload
+
+      expect(response).to redirect_to profile_path(peyton.profile.id)
+      expect(peyton.profile.full_name).to eq 'Peyton Manning'
+      expect(peyton.profile.bio).to eq 'Former NFL quarterback, 5x NFL MVP'
+      expect(peyton.profile.country).to eq 'USA'
+      expect(peyton.profile.age).to eq 47
+    end
+
+    it 'successfully from the profile page, removing one or more information from the profile' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      peyton.profile.update(bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA', birth_date: 47.years.ago)
+      profile_params = { profile:
+        { full_name: '',
+          bio: '',
+          country: 'USA',
+          birth_date: '' } }
+
+      login_as peyton
+      patch profile_path(peyton.profile.id), params: profile_params
+      peyton.profile.reload
+
+      expect(response).to redirect_to profile_path(peyton.profile.id)
+      expect(peyton.profile.full_name).to eq ''
+      expect(peyton.profile.bio).to eq ''
+      expect(peyton.profile.country).to eq 'USA'
+      expect(peyton.profile.age).to be_nil
+    end
+  end
+
+  context 'without authorization' do
+    it 'fails to update and redirects to homepage' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      patrick = User.create!(username: 'grimreaper', email: 'patrick@mahomes.com', password: 'chiefskingdom')
+      profile_params = { profile:
+        { full_name: 'Peyton Manning',
+          bio: 'Former NFL quarterback, 5x NFL MVP',
+          country: 'USA',
+          birth_date: 47.years.ago.strftime('%Y-%m-%d') } }
+
+      login_as patrick
+      patch profile_path(peyton.profile.id), params: profile_params
+      peyton.profile.reload
+
+      expect(response).to redirect_to root_path
+      expect(peyton.profile.full_name).to be_nil
+      expect(peyton.profile.bio).to be_nil
+      expect(peyton.profile.country).to be_nil
+      expect(peyton.profile.age).to be_nil
+    end
+  end
+
+  context 'while unauthenticated' do
+    it 'fails to update and redirects to login page' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      profile_params = { profile:
+        { full_name: 'Peyton Manning',
+          bio: 'Former NFL quarterback, 5x NFL MVP',
+          country: 'USA',
+          birth_date: 47.years.ago.strftime('%Y-%m-%d') } }
+
+      patch profile_path(peyton.profile.id), params: profile_params
+      peyton.profile.reload
+
+      expect(response).to redirect_to new_user_session_path
+      expect(peyton.profile.full_name).to be_nil
+      expect(peyton.profile.bio).to be_nil
+      expect(peyton.profile.country).to be_nil
+      expect(peyton.profile.age).to be_nil
+    end
+  end
+end

--- a/spec/system/devise/user_signs_in_spec.rb
+++ b/spec/system/devise/user_signs_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'User signs up, starting from the homepage', type: :system do
   it 'successfully' do
-    User.create(email: 'patrick@mahomes.com', password: 'arrowhead15')
+    User.create(username: 'sheriff18', email: 'patrick@mahomes.com', password: 'arrowhead15')
 
     visit root_path
     click_on 'Login'
@@ -16,7 +16,7 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
 
   context 'unsuccessfully if' do
     it 'fails to provide an e-mail address' do
-      User.create(email: 'patrick@mahomes.com', password: 'arrowhead15')
+      User.create(username: 'sheriff18', email: 'patrick@mahomes.com', password: 'arrowhead15')
 
       visit root_path
       click_on 'Login'
@@ -29,7 +29,7 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
     end
 
     it 'provides an invalid e-mail address' do
-      User.create(email: 'patrick@mahomes.com', password: 'arrowhead15')
+      User.create(username: 'sheriff18', email: 'patrick@mahomes.com', password: 'arrowhead15')
 
       visit root_path
       click_on 'Login'
@@ -42,7 +42,7 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
     end
 
     it 'fails to provide a password' do
-      User.create(email: 'patrick@mahomes.com', password: 'arrowhead15')
+      User.create(username: 'sheriff18', email: 'patrick@mahomes.com', password: 'arrowhead15')
 
       visit root_path
       click_on 'Login'
@@ -55,7 +55,7 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
     end
 
     it 'provides an incorrect password' do
-      User.create(email: 'patrick@mahomes.com', password: 'arrowhead15')
+      User.create(username: 'sheriff18', email: 'patrick@mahomes.com', password: 'arrowhead15')
 
       visit root_path
       click_on 'Login'

--- a/spec/system/devise/user_signs_up_spec.rb
+++ b/spec/system/devise/user_signs_up_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
     expect(User.last.email).to eq 'billy@pampers.com'
     expect(page).to have_content('Bem vindo! Você realizou seu registro com sucesso.')
     expect(page).to have_current_path(root_path)
-    expect(page).to have_content 'billy@pampers.com'
+    expect(page).to have_content 'elBillyPampers'
     expect(page).to have_button 'Sair'
     expect(page).not_to have_link 'Inscrever-se', href: new_user_registration_path
     expect(page).not_to have_link 'Login', href: new_user_session_path

--- a/spec/system/devise/user_signs_up_spec.rb
+++ b/spec/system/devise/user_signs_up_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
   it 'successfully' do
     visit root_path
     click_on 'Inscrever-se'
+    fill_in 'Nome de usuário', with: 'elBillyPampers'
     fill_in 'E-mail', with: 'billy@pampers.com'
     fill_in 'Senha', with: '123456'
     fill_in 'Confirme sua senha', with: '123456'
@@ -33,8 +34,22 @@ RSpec.describe 'User signs up, starting from the homepage', type: :system do
       expect(page).to have_content 'E-mail não pode ficar em branco'
     end
 
+    it 'fails to provide an username' do
+      visit root_path
+      click_on 'Inscrever-se'
+      fill_in 'Nome de usuário', with: ''
+      fill_in 'E-mail', with: 'peyton@manning.com'
+      fill_in 'Senha', with: '123456'
+      fill_in 'Confirme sua senha', with: '123456'
+      click_on 'Cadastrar'
+
+      expect(User.count).to eq 0
+      expect(page).to have_content 'Não foi possível salvar usuário'
+      expect(page).to have_content 'Nome de usuário não pode ficar em branco'
+    end
+
     it 'uses an already registered e-mail address' do
-      User.create!(email: 'peyton@manning.com', password: 'laserqb18')
+      User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'laserqb18')
 
       visit root_path
       click_on 'Inscrever-se'

--- a/spec/system/profile/user_edits_profile_spec.rb
+++ b/spec/system/profile/user_edits_profile_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'User edits profile', type: :system do
   context 'with authorization' do
-    it 'successfully from the profile page' do
+    it 'successfully from the profile page, changing all of the information at once' do
       peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
 
       login_as peyton
@@ -20,6 +20,61 @@ RSpec.describe 'User edits profile', type: :system do
       expect(page).to have_content 'Former NFL quarterback, 5x NFL MVP'
       expect(page).to have_content 'USA'
       expect(page).to have_content '47 anos'
+    end
+
+    it 'successfully from the profile page, removing one or more information from the profile' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      peyton.profile.update(bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA', birth_date: 47.years.ago)
+
+      login_as peyton
+      visit profile_path(peyton.profile.id)
+      click_on 'Editar perfil'
+      fill_in 'Nome completo', with: 'Peyton Manning'
+      fill_in 'Bio', with: 'Former NFL quarterback, 5x NFL MVP'
+      fill_in 'País', with: ''
+      fill_in 'Data de nascimento', with: ''
+      click_on 'Salvar'
+
+      expect(page).to have_current_path profile_path(peyton.profile.id)
+      expect(page).to have_content 'Seu perfil foi alterado com sucesso'
+      expect(page).to have_content 'Peyton Manning'
+      expect(page).to have_content 'Former NFL quarterback, 5x NFL MVP'
+      expect(page).not_to have_content 'USA'
+      expect(page).not_to have_content '47 anos'
+    end
+  end
+
+  context 'without authorization' do
+    it 'so it does not see the edit profile link on profile page' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      patrick = User.create(username: 'grimreaper', email: 'patrick@mahomes.com', password: 'chiefskingdom')
+
+      login_as patrick
+      visit profile_path(peyton.profile.id)
+
+      expect(page).not_to have_link 'Editar perfil', href: edit_profile_path(peyton.profile.id)
+    end
+
+    it 'so it is redirected to homepage if tries to access the edit profile url' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      patrick = User.create(username: 'grimreaper', email: 'patrick@mahomes.com', password: 'chiefskingdom')
+
+      login_as patrick
+      visit edit_profile_path(peyton.profile.id)
+
+      expect(page).to have_content 'Você não possui autorização para essa ação'
+      expect(page).to have_current_path root_path
+    end
+  end
+
+  context 'while unauthenticated' do
+    it 'so it is redirected to login page if tries to access the edit profile url' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+
+      visit edit_profile_path(peyton.profile.id)
+
+      expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+      expect(page).to have_current_path new_user_session_path
     end
   end
 end

--- a/spec/system/profile/user_edits_profile_spec.rb
+++ b/spec/system/profile/user_edits_profile_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'User edits profile', type: :system do
+  context 'with authorization' do
+    it 'successfully from the profile page' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+
+      login_as peyton
+      visit profile_path(peyton.profile.id)
+      click_on 'Editar perfil'
+      fill_in 'Nome completo', with: 'Peyton Manning'
+      fill_in 'Bio', with: 'Former NFL quarterback, 5x NFL MVP'
+      fill_in 'País', with: 'USA'
+      fill_in 'Data de nascimento', with: 47.years.ago.strftime('%Y-%m-%d')
+      click_on 'Salvar'
+
+      expect(page).to have_current_path profile_path(peyton.profile.id)
+      expect(page).to have_content 'Seu perfil foi alterado com sucesso'
+      expect(page).to have_content 'Peyton Manning'
+      expect(page).to have_content 'Former NFL quarterback, 5x NFL MVP'
+      expect(page).to have_content 'USA'
+      expect(page).to have_content '47 anos'
+    end
+  end
+end

--- a/spec/system/profile/user_visits_profile_spec.rb
+++ b/spec/system/profile/user_visits_profile_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'User visits profile', type: :system do
   context 'while authenticated' do
-    it 'successfully and sees the profile details' do
+    it 'successfully and sees the own profile details' do
       user = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
       user.profile.update!(full_name: 'Peyton Manning', bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA',
                            birth_date: '1976-03-24')
@@ -12,10 +12,69 @@ RSpec.describe 'User visits profile', type: :system do
       click_on 'sheriff18'
 
       expect(page).to have_current_path profile_path(user.profile.id)
-      expect(page).to have_content('Peyton Manning')
-      expect(page).to have_content('Former NFL quarterback, 5x NFL MVP')
-      expect(page).to have_content('USA')
-      expect(page).to have_content('47 anos')
+      expect(page).to have_content 'Peyton Manning'
+      expect(page).to have_content 'Former NFL quarterback, 5x NFL MVP'
+      expect(page).to have_content 'USA'
+      expect(page).to have_content '47 anos'
+    end
+
+    it 'successfully and sees another user profile details' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      peyton.profile.update!(full_name: 'Peyton Manning', bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA',
+                           birth_date: '1976-03-24')
+      patrick = User.create!(username: 'grimreaper', email: 'patrick@mahomes.com', password: 'chiefskingdom')
+
+      login_as patrick
+      visit profile_path(peyton.profile.id)
+
+      expect(page).to have_current_path profile_path(peyton.profile.id)
+      expect(page).to have_content 'sheriff18'
+      expect(page).to have_content 'Peyton Manning'
+      expect(page).to have_content 'Former NFL quarterback, 5x NFL MVP'
+      expect(page).to have_content 'USA'
+      expect(page).to have_content '47 anos'
+    end
+
+    it 'and returns to the homepage' do
+      user = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      user.profile.update!(full_name: 'Peyton Manning', bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA',
+                           birth_date: '1976-03-24')
+
+      login_as user
+      visit profile_path(user.profile.id)
+      click_on 'GamingSocialNetwork'
+
+      expect(page).to have_current_path root_path
+      expect(page).not_to have_content 'Peyton Manning'
+      expect(page).not_to have_content 'Former NFL quarterback, 5x NFL MVP'
+      expect(page).not_to have_content 'USA'
+      expect(page).not_to have_content '47 anos'
+    end
+
+    it 'and only sees the username if the user has not updated its profile information' do
+      peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      patrick = User.create!(username: 'grimreaper', email: 'patrick@mahomes.com', password: 'chiefskingdom')
+
+      login_as patrick
+      visit profile_path(peyton.profile.id)
+
+      expect(page).to have_current_path profile_path(peyton.profile.id)
+      expect(page).to have_content 'sheriff18'
+      expect(page).not_to have_content 'Peyton Manning'
+      expect(page).not_to have_content 'Former NFL quarterback, 5x NFL MVP'
+      expect(page).not_to have_content 'USA'
+      expect(page).not_to have_content '47 anos'
+    end
+  end
+
+  context 'while unauthenticated' do
+    it 'and is redirected to the login page' do
+      user = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+
+      visit profile_path(user.profile.id)
+
+      expect(page).to have_current_path new_user_session_path
+      expect(page).to have_content 'Para continuar, faça login ou registre-se.'
     end
   end
 end

--- a/spec/system/profile/user_visits_profile_spec.rb
+++ b/spec/system/profile/user_visits_profile_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'User visits profile', type: :system do
     it 'successfully and sees another user profile details' do
       peyton = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
       peyton.profile.update!(full_name: 'Peyton Manning', bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA',
-                           birth_date: '1976-03-24')
+                             birth_date: '1976-03-24')
       patrick = User.create!(username: 'grimreaper', email: 'patrick@mahomes.com', password: 'chiefskingdom')
 
       login_as patrick

--- a/spec/system/profile/user_visits_profile_spec.rb
+++ b/spec/system/profile/user_visits_profile_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'User visits profile', type: :system do
+  context 'while authenticated' do
+    it 'successfully and sees the profile details' do
+      user = User.create!(username: 'sheriff18', email: 'peyton@manning.com', password: 'broncocolts18')
+      user.profile.update!(full_name: 'Peyton Manning', bio: 'Former NFL quarterback, 5x NFL MVP', country: 'USA',
+                           birth_date: '1976-03-24')
+
+      login_as user
+      visit root_path
+      click_on 'sheriff18'
+
+      expect(page).to have_current_path profile_path(user.profile.id)
+      expect(page).to have_content('Peyton Manning')
+      expect(page).to have_content('Former NFL quarterback, 5x NFL MVP')
+      expect(page).to have_content('USA')
+      expect(page).to have_content('47 anos')
+    end
+  end
+end


### PR DESCRIPTION
## Issues resolvidas com essa PR
- Resolve #3
- Resolve #4
- Resolve #7  

## Com essa PR, os seguintes objetivos são concluídos:
- [x] Instancia de perfil do usuário é criada imediatamente após o cadastro na plataforma;
- [x] Usuário é capaz de alterar seu perfil a partir da página de perfil
- [x] Apenas usuários autenticados e autorizados podem fazer a alteração do perfil (leia-se: apenas o próprio dono do perfil pode fazer a alteração).

![image](https://github.com/eliseuramos93/gaming-social-network/assets/111306649/43378043-8b3f-43c8-baa9-2d66fb26de7a)

![image](https://github.com/eliseuramos93/gaming-social-network/assets/111306649/41c112a3-a4bb-4281-ab19-d2c9e3e28e24)

Como não existe um formulário de criação de novo perfil, não foi criada _partial_ para o formulário de edição do perfil.